### PR TITLE
add set_use_camera_wb and set_use_camera_matrix

### DIFF
--- a/rsraw/src/raw.rs
+++ b/rsraw/src/raw.rs
@@ -181,6 +181,21 @@ impl RawImage {
         }
     }
 
+    /// If possible, use the white balance from the camera.
+    /// If not available, Auto-WB is used.
+    pub fn set_use_camera_wb(&mut self, enable: bool) {
+        unsafe {
+            (*self.raw_data).params.use_camera_wb = if enable { 1 } else { 0 };
+        }
+    }
+
+    /// On by default, call if you want to force use of DNG embedded matrix.
+    pub fn set_use_camera_matrix(&mut self, enable: bool) {
+        unsafe {
+            (*self.raw_data).params.use_camera_matrix = if enable { 3 } else { 0 };
+        }
+    }
+
     pub fn process<const D: BitDepth>(&mut self) -> Result<ProcessedImage<D>> {
         debug_assert!(D == BIT_DEPTH_8 || D == BIT_DEPTH_16);
         unsafe { (*self.raw_data).params.output_bps = D as i32 };


### PR DESCRIPTION
Added features: set_use_camera_wb and set_use_camera_matrix .

usage:
https://github.com/Safari77/rupphash/commit/8e048115db06a8c3686a46bc18e14ed0d18f809a

comparison, before:
<img width="1307" height="832" alt="rsraw-nowb" src="https://github.com/user-attachments/assets/cd4050bc-d54e-4f8a-a47b-46825b8757cf" />
after:
<img width="1534" height="981" alt="rsraw-with-wb" src="https://github.com/user-attachments/assets/b99a82ad-016c-42a2-bf9d-9a079da8a3b7" />

