### PR TITLE
Add manual GitHub Actions workflow to publish rsraw and rsraw-sys to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release to crates.io
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+
+jobs:
+  publish:
+    name: Publish crates
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish rsraw-sys
+        run: cargo publish -p rsraw-sys --locked
+
+      - name: Wait for crates.io index to update
+        run: sleep 30
+
+      - name: Publish rsraw
+        run: cargo publish -p rsraw --locked


### PR DESCRIPTION
### Motivation

- Provide a manual release workflow so maintainers can publish the two workspace crates to crates.io on demand.
- Ensure the publish job only runs when triggered from the `main` branch to avoid accidental publishes from other refs.
- Use the repository secret `CRATES_IO_TOKEN` for authentication with crates.io.

### Description

- Add a new workflow file at `.github/workflows/release.yml` that is triggered by `workflow_dispatch` and sets `CARGO_REGISTRY_TOKEN` from `secrets.CRATES_IO_TOKEN`.
- Configure `concurrency` with `group: release-${{ github.ref }}` and `if: github.ref == 'refs/heads/main'` to serialize releases and restrict execution to `main`.
- The job checks out the repo, installs Rust via `dtolnay/rust-toolchain@stable`, then runs `cargo publish -p rsraw-sys --locked`, waits briefly, and runs `cargo publish -p rsraw --locked`.

### Testing

- Validated the workflow YAML by running `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"` which parsed successfully.
- Verified workspace metadata with `cargo metadata --no-deps` which completed without error.
- Performed a local syntax/structure review of the created file at `.github/workflows/release.yml` and confirmed the expected steps and environment variables are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bea43a4bb08332806f2752fbab1855)